### PR TITLE
use public ip for the replica

### DIFF
--- a/docker-data/start.sh
+++ b/docker-data/start.sh
@@ -1,4 +1,6 @@
 supervisord
 sleep 3
-echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
+
+IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
+echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
 tail -f /var/log/supervisor/redis-1.log


### PR DESCRIPTION
use public ip of the docker container to create replica so that java client on docker image can use this  cluster. Otherwise java redis cluster driver will got 127.0.0.1 when discovering cluster nodes.
