### PR TITLE
Use redis base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# This tag use ubuntu 14.04
-FROM phusion/baseimage:0.9.16
+FROM redis:3.2.4
 
 MAINTAINER Johan Andersson <Grokzen@gmail.com>
 
@@ -7,57 +6,37 @@ MAINTAINER Johan Andersson <Grokzen@gmail.com>
 ENV HOME /root
 ENV DEBIAN_FRONTEND noninteractive
 
+# Install system dependencies
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -yqq \
+      net-tools supervisor ruby rubygems locales gettext-base && \
+    apt-get clean -yqq
+
 # # Ensure UTF-8 lang and locale
 RUN locale-gen en_US.UTF-8
 ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
 
-# Initial update and install of dependency that can add apt-repos
-RUN apt-get -y update && apt-get install -y software-properties-common python-software-properties
-
-# Add global apt repos
-RUN add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu precise universe" && \
-    add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu precise main restricted universe multiverse" && \
-    add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu precise-updates main restricted universe multiverse" && \
-    add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse"
-RUN apt-get update && apt-get -y upgrade
-
-# Install system dependencies
-RUN apt-get install -y gcc make g++ build-essential libc6-dev tcl git supervisor ruby
-
-# Must be installed seperate from ruby or it will complain about broken package
-RUN apt-get install -y rubygems
-
-# Install ruby dependencies so we can bootstrap the cluster via redis-trib.rb
 RUN gem install redis
 
-# checkout the 3.0.6 tag (Will change to 3.2 tag when it is released as stable)
-RUN git clone -b 3.0.6 https://github.com/antirez/redis.git
+RUN wget -qO redis.tar.gz $REDIS_DOWNLOAD_URL \
+    && echo "$REDIS_DOWNLOAD_SHA1 *redis.tar.gz" | sha1sum -c - \
+    && tar xfz redis.tar.gz -C / \
+    && mv /redis-$REDIS_VERSION /redis
 
-# Build redis from source
-RUN (cd /redis && make)
+RUN mkdir /redis-conf
 
-# Because Git cannot track empty folders we have to create them manually...
-RUN mkdir /redis-data && \
-    mkdir /redis-data/7000 && \
-    mkdir /redis-data/7001 && \
-    mkdir /redis-data/7002 && \
-    mkdir /redis-data/7003 && \
-    mkdir /redis-data/7004 && \
-    mkdir /redis-data/7005 && \
-    mkdir /redis-data/7006 && \
-    mkdir /redis-data/7007
-
-# Add all config files for all clusters
-ADD ./docker-data/redis-conf /redis-conf
+COPY ./docker-data/redis-cluster.tmpl /redis-cluster.tmpl
+COPY ./docker-data/redis.tmpl /redis.tmpl
 
 # Add supervisord configuration
-ADD ./docker-data/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY ./docker-data/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add startup script
-ADD ./docker-data/start.sh /start.sh
-RUN chmod 755 /start.sh
+COPY ./docker-data/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod 755 /docker-entrypoint.sh
 
 EXPOSE 7000 7001 7002 7003 7004 7005 7006 7007
 
-CMD ["/bin/bash", "/start.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["redis-cluster"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,10 @@ RUN wget -qO redis.tar.gz $REDIS_DOWNLOAD_URL \
     && mv /redis-$REDIS_VERSION /redis
 
 RUN mkdir /redis-conf
+RUN mkdir /redis-data
 
-COPY ./docker-data/redis-cluster.tmpl /redis-cluster.tmpl
-COPY ./docker-data/redis.tmpl /redis.tmpl
+COPY ./docker-data/redis-cluster.tmpl /redis-conf/redis-cluster.tmpl
+COPY ./docker-data/redis.tmpl /redis-conf/redis.tmpl
 
 # Add supervisord configuration
 COPY ./docker-data/supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CID_FILE = /tmp/grokzen-redis-cluster.cid
 CID =`cat $(CID_FILE)`
-IMAGE_NAME = grokzen/redis-cluster
+IMAGE_NAME = dpetzold/redis-cluster
 PORTS = -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 -p 7006:7006 -p 7007:7007
 
 help:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-server:
+redis-cluster:
   build: .
   hostname: server
-  expose:
+  ports:
     - "7000:7000"
     - "7001:7001"
     - "7002:7002"

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -4,6 +4,10 @@ if [ "$1" = 'redis-cluster' ]; then
     for port in `seq 7000 7007`; do
       mkdir -p /redis-conf/${port}
       mkdir -p /redis-data/${port}
+
+      if [ -e /redis-data/${port}/nodes.conf ]; then
+        rm /redis-data/${port}/nodes.conf
+      fi
     done
 
     for port in `seq 7000 7005`; do

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
 
 if [ "$1" = 'redis-cluster' ]; then
-    for port in `seq 7000 7005`; do
+    for port in `seq 7000 7007`; do
       mkdir -p /redis-conf/${port}
-      mkdir -p /data/${port}
-      PORT=${port} envsubst < /redis-cluster.tmpl > /redis-conf/${port}/redis.conf
+      mkdir -p /redis-data/${port}
+    done
+
+    for port in `seq 7000 7005`; do
+      PORT=${port} envsubst < /redis-conf/redis-cluster.tmpl > /redis-conf/${port}/redis.conf
     done
 
     for port in `seq 7006 7007`; do
-      mkdir -p /redis-conf/${port}
-      mkdir -p /data/${port}
-      PORT=${port} envsubst < /redis.tmpl > /redis-conf/${port}/redis.conf
+      PORT=${port} envsubst < /redis-conf/redis.tmpl > /redis-conf/${port}/redis.conf
     done
 
     supervisord -c /etc/supervisor/supervisord.conf

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ "$1" = 'redis-cluster' ]; then
+    for port in `seq 7000 7005`; do
+      mkdir -p /redis-conf/${port}
+      mkdir -p /data/${port}
+      PORT=${port} envsubst < /redis-cluster.tmpl > /redis-conf/${port}/redis.conf
+    done
+
+    for port in `seq 7006 7007`; do
+      mkdir -p /redis-conf/${port}
+      mkdir -p /data/${port}
+      PORT=${port} envsubst < /redis.tmpl > /redis-conf/${port}/redis.conf
+    done
+
+    supervisord -c /etc/supervisor/supervisord.conf
+    sleep 3
+
+    IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
+    echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
+    tail -f /var/log/supervisor/redis*.log
+else
+  exec "$@"
+fi

--- a/docker-data/redis-cluster.tmpl
+++ b/docker-data/redis-cluster.tmpl
@@ -1,6 +1,7 @@
-port 7005
+port ${PORT}
 cluster-enabled yes
 cluster-config-file nodes.conf
 cluster-node-timeout 5000
 appendonly yes
-dir /redis-data/7005
+dir /data/${PORT}
+protected-mode no

--- a/docker-data/redis-cluster.tmpl
+++ b/docker-data/redis-cluster.tmpl
@@ -3,5 +3,5 @@ cluster-enabled yes
 cluster-config-file nodes.conf
 cluster-node-timeout 5000
 appendonly yes
-dir /data/${PORT}
+dir /redis-data/${PORT}
 protected-mode no

--- a/docker-data/redis-conf/7000/redis.conf
+++ b/docker-data/redis-conf/7000/redis.conf
@@ -1,6 +1,0 @@
-port 7000
-cluster-enabled yes
-cluster-config-file nodes.conf
-cluster-node-timeout 5000
-appendonly yes
-dir /redis-data/7000

--- a/docker-data/redis-conf/7001/redis.conf
+++ b/docker-data/redis-conf/7001/redis.conf
@@ -1,6 +1,0 @@
-port 7001
-cluster-enabled yes
-cluster-config-file nodes.conf
-cluster-node-timeout 5000
-appendonly yes
-dir /redis-data/7001

--- a/docker-data/redis-conf/7002/redis.conf
+++ b/docker-data/redis-conf/7002/redis.conf
@@ -1,6 +1,0 @@
-port 7002
-cluster-enabled yes
-cluster-config-file nodes.conf
-cluster-node-timeout 5000
-appendonly yes
-dir /redis-data/7002

--- a/docker-data/redis-conf/7003/redis.conf
+++ b/docker-data/redis-conf/7003/redis.conf
@@ -1,6 +1,0 @@
-port 7003
-cluster-enabled yes
-cluster-config-file nodes.conf
-cluster-node-timeout 5000
-appendonly yes
-dir /redis-data/7003

--- a/docker-data/redis-conf/7004/redis.conf
+++ b/docker-data/redis-conf/7004/redis.conf
@@ -1,6 +1,0 @@
-port 7004
-cluster-enabled yes
-cluster-config-file nodes.conf
-cluster-node-timeout 5000
-appendonly yes
-dir /redis-data/7004

--- a/docker-data/redis-conf/7006/redis.conf
+++ b/docker-data/redis-conf/7006/redis.conf
@@ -1,3 +1,0 @@
-port 7006
-appendonly yes
-dir /redis-data/7006

--- a/docker-data/redis-conf/7007/redis.conf
+++ b/docker-data/redis-conf/7007/redis.conf
@@ -1,3 +1,0 @@
-port 7007
-appendonly yes
-dir /redis-data/7007

--- a/docker-data/redis.tmpl
+++ b/docker-data/redis.tmpl
@@ -1,0 +1,4 @@
+port ${PORT}
+appendonly yes
+dir /data/${PORT}
+protected-mode no

--- a/docker-data/redis.tmpl
+++ b/docker-data/redis.tmpl
@@ -1,4 +1,4 @@
 port ${PORT}
 appendonly yes
-dir /data/${PORT}
+dir /redis-data/${PORT}
 protected-mode no

--- a/docker-data/start.sh
+++ b/docker-data/start.sh
@@ -1,6 +1,0 @@
-supervisord
-sleep 3
-
-IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
-echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
-tail -f /var/log/supervisor/redis-1.log

--- a/docker-data/supervisord.conf
+++ b/docker-data/supervisord.conf
@@ -2,49 +2,49 @@
 nodaemon=false
 
 [program:redis-1]
-command=/redis/src/redis-server /redis-conf/7000/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7000/redis.conf 
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:redis-2]
-command=/redis/src/redis-server /redis-conf/7001/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7001/redis.conf
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:redis-3]
-command=/redis/src/redis-server /redis-conf/7002/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7002/redis.conf
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:redis-4]
-command=/redis/src/redis-server /redis-conf/7003/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7003/redis.conf
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:redis-5]
-command=/redis/src/redis-server /redis-conf/7004/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7004/redis.conf
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:redis-6]
-command=/redis/src/redis-server /redis-conf/7005/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7005/redis.conf
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:redis-7]
-command=/redis/src/redis-server /redis-conf/7006/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7006/redis.conf
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:redis-8]
-command=/redis/src/redis-server /redis-conf/7007/redis.conf
+command=/usr/local/bin/redis-server /redis-conf/7007/redis.conf
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true


### PR DESCRIPTION
Redis is now at version 3.2.4 and no longer needs to be compiled. Below are the other changes:
- Renamed compose.yml -> docker-compose.yml
- Moved redis configuration to templates.
- Renamed to start.sh to docker-entrypoint.sh. Updated it to provide a consistent interface.
- Use provided download url and verify the checksum.
- Tail all the logs.
