### PR TITLE
Fix cluster can't run on MacOS

### DIFF
--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -21,7 +21,6 @@ if [ "$1" = 'redis-cluster' ]; then
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 3
 
-    IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
     IP=0.0.0.0
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -22,6 +22,7 @@ if [ "$1" = 'redis-cluster' ]; then
     sleep 3
 
     IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
+    IP=0.0.0.0
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log
 else


### PR DESCRIPTION
On MacOS, it will using the docker local address like '172.0.1.2', this won't work because of [this](https://docs.docker.com/docker-for-mac/networking/)

Says: 
```
Unfortunately, due to limitations in macOS, we’re unable to route traffic to containers, and from containers back to the host.
```

fortunately, update to ```0.0.0.0``` will fix this.
:)
I've tested.