### PR TITLE
Fix SSL failures due to SHA1/SHA2 switchover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN locale-gen en_US.UTF-8
 ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
 
+# Necessary for gem installs due to SHA1 being weak and old cert being revoked
+ENV SSL_CERT_FILE=/usr/local/etc/openssl/cert.pem
+
 RUN gem install redis
 
 RUN apt-get install -y gcc make g++ build-essential libc6-dev tcl git supervisor ruby


### PR DESCRIPTION
Without this change `gem install redis` will fail:

```
Step 9/23 : RUN gem install redis
 ---> Running in 0ad3417c9c99
ERROR:  Could not find a valid gem 'redis' (>= 0), here is why:
          Unable to download data from https://rubygems.org/ - SSL_connect returned=1 errno=0 state=error: certificate verify failed (https://api.rubygems.org/latest_specs.4.8.gz)
ERROR: Service 'redis-cluster' failed to build: The command '/bin/sh -c gem install redis' returned a non-zero code: 2
```