### PR TITLE
wget is required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install system dependencies
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -yqq \
-      net-tools supervisor ruby rubygems locales gettext-base && \
+      net-tools supervisor ruby rubygems locales gettext-base wget && \
     apt-get clean -yqq
 
 # # Ensure UTF-8 lang and locale


### PR DESCRIPTION
## # Problem:
```
/bin/sh: 1: wget: not found
ERROR: Service 'redis-cluster' failed to build: The command '/bin/sh -c wget -qO redis.tar.gz http://download.redis.io/releases/redis-${redis_version}.tar.gz     && tar xfz redis.tar.gz -C /     && mv /redis-$redis_version /redis' returned a non-zero code: 127
```

## # Solution

Insert **_wget_** on container installation.