### PR TITLE
Install wget before it's used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL     en_US.UTF-8
 
 RUN gem install redis
 
-RUN apt-get install -y gcc make g++ build-essential libc6-dev tcl git supervisor ruby
+RUN apt-get install -y wget gcc make g++ build-essential libc6-dev tcl git supervisor ruby
 
 ARG redis_version=3.2.9
 


### PR DESCRIPTION
Hi, I was getting `wget: not found` error without explicitly installing it, thus I added it docker file