### PR TITLE
Only take the first IP address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL     en_US.UTF-8
 
 RUN gem install redis
 
-RUN apt-get install -y gcc make g++ build-essential libc6-dev tcl git supervisor ruby
+RUN apt-get install -y gcc make g++ build-essential libc6-dev tcl git supervisor ruby wget
 
 ARG redis_version=3.2.9
 

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'redis-cluster' ]; then
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 3
 
-    IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
+    IP=`ifconfig | grep "inet addr:17" | head -n 1 | cut -f2 -d ":" | cut -f1 -d " "`
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log
 else


### PR DESCRIPTION
We had a scenario, where there were two interfaces with an 172.x.x.x IP address. The grep returned two lines and then the outcome were two IP addresses separated by a new line. This patch only takes the first IP address.