### PR TITLE
Reset default IP to discovered one but allow custom IPs via env var or command arg

### DIFF
--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -27,7 +27,6 @@ if [ "$1" = 'redis-cluster' ]; then
     sleep 3
 
     IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
-    IP=0.0.0.0
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log
 else

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 if [ "$1" = 'redis-cluster' ]; then
+    # Allow passing in cluster IP by argument or environmental variable
+    IP="${2:-$IP}"
+
     max_port=7007
     if [ "$CLUSTER_ONLY" = "true" ]; then
       max_port=7005
@@ -26,7 +29,10 @@ if [ "$1" = 'redis-cluster' ]; then
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 3
 
-    IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
+    # If IP is unset then discover it
+    if [ -z "$IP" ]; then
+        IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
+    fi
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log
 else

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -26,6 +26,7 @@ if [ "$1" = 'redis-cluster' ]; then
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 3
 
+    IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
     IP=0.0.0.0
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log


### PR DESCRIPTION
Use IP behaviour from before commit ccd7f28b74 but allow user to specify
an IP either by additional argument to entrypoint or by environmental
variable.

Fixes #37

---

Tested with following docker compose file;

```yaml
version: '2'
services:
  redis-cluster:
    # environment:
    #  IP: 0.0.0.0
    # command: redis-cluster 0.0.0.0
    build:
      context: .
      args:
        redis_version: '3.2.9'
    hostname: server
    ports:
      - '7000-7007:7000-7007'
  cli:
    depends_on:
      - redis-cluster
    image: redis
    entrypoint: redis-cli -c -h redis-cluster -p 7000
```

With environment and command toggled out we get the old behaviour and
the following output;

```
> docker-compose run cli CLUSTER SLOTS
Starting docker-redis-cluster_redis-cluster_1 ... done
1) 1) (integer) 10923
   2) (integer) 16383
   3) 1) "172.21.0.2"
      2) (integer) 7002
      3) "b6e7d7eaf625816ceb4508998626c79808a84365"
   4) 1) "172.21.0.2"
      2) (integer) 7005
      3) "2a177937ab9747c8db154d36a576d7dc115684fb"
2) 1) (integer) 0
   2) (integer) 5460
   3) 1) "172.21.0.2"
      2) (integer) 7000
      3) "5c5b002ec158f179789e989e9bd7567a958e6b83"
   4) 1) "172.21.0.2"
      2) (integer) 7003
      3) "3767c710a43603b9fd6e01a1ceba779277b43387"
3) 1) (integer) 5461
   2) (integer) 10922
   3) 1) "172.21.0.2"
      2) (integer) 7001
      3) "8a3b9d9e1e8e624de931c1c3a62d373834be250e"
   4) 1) "172.21.0.2"
      2) (integer) 7004
      3) "b3fe29445bc59ef941981ab94bdf4af272a7060c"

> docker-compose run cli set foo bar
Starting docker-redis-cluster_redis-cluster_1 ... done
OK
```

Passing in IP with either environment or command we get the new
behaviour;

```
> docker-compose run cli CLUSTER SLOTS
Starting docker-redis-cluster_redis-cluster_1 ... done
1) 1) (integer) 5461
   2) (integer) 10922
   3) 1) "127.0.0.1"
      2) (integer) 7001
      3) "60699d193c7564bdc4faac49f1436a7062ecf6d4"
   4) 1) "127.0.0.1"
      2) (integer) 7004
      3) "92f70fb4e0e720e4758e7ecfd8f6c0c63348a070"
2) 1) (integer) 0
   2) (integer) 5460
   3) 1) "127.0.0.1"
      2) (integer) 7000
      3) "63cd673f0bbbd55276f7b8832601cba2d6d53a27"
   4) 1) "127.0.0.1"
      2) (integer) 7003
      3) "92e0409966506b79247b6d8f0fc04a547dd4070b"
3) 1) (integer) 10923
   2) (integer) 16383
   3) 1) "127.0.0.1"
      2) (integer) 7002
      3) "6d518b7180df92c01246aad0d75942f555acdc88"
   4) 1) "127.0.0.1"
      2) (integer) 7005
      3) "207ea6eea84076cc97adff264228fc88f1cd4ad9"

> docker-compose run cli set foo bar
Starting docker-redis-cluster_redis-cluster_1 ... done
Could not connect to Redis at 127.0.0.1:7002: Connection refused
Could not connect to Redis at 127.0.0.1:7002: Connection refused
```
