### PR TITLE
Adding optional Sentinels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN mkdir /redis-data
 
 COPY ./docker-data/redis-cluster.tmpl /redis-conf/redis-cluster.tmpl
 COPY ./docker-data/redis.tmpl /redis-conf/redis.tmpl
+COPY ./docker-data/sentinel.tmpl /redis-conf/sentinel.tmpl
 
 # Add startup script
 COPY ./docker-data/docker-entrypoint.sh /docker-entrypoint.sh
@@ -46,7 +47,7 @@ COPY ./docker-data/generate-supervisor-conf.sh /generate-supervisor-conf.sh
 
 RUN chmod 755 /docker-entrypoint.sh
 
-EXPOSE 7000 7001 7002 7003 7004 7005 7006 7007
+EXPOSE 7000 7001 7002 7003 7004 7005 7006 7007 5000 5001 5002
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["redis-cluster"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The main usage for this container is to test redis cluster code. For example in 
 
 The cluster is 6 redis instances running with 3 master & 3 slaves, one slave for each master. They run on ports 7000 to 7005.
 
+If the flag `-e "SENTINEL=true"` is passed there are 3 Sentinel nodes running on ports 5000 to 5002 matching cluster's master instances.
+
 It also contains 2 standalone instances that is not part of the cluster. They are running on port 7006 & 7007
 
 This image requires at least `Docker` version 1.10 but the latest version is recommended.
@@ -81,6 +83,15 @@ Set env variable CLUSTER_ONLY=true.
 * Running with docker directly add:
 
       docker run ... -e CLUSTER_ONLY=true ...
+
+
+## Include sentinel instances
+
+Sentinel instances is not enabled by default.
+
+When running with docker-compose set the environment variable on your system `REDIS_USE_SENTINEL=true` and start your container.
+
+If running with plain docker send in `-e SENTINEL=true`.
 
 
 ## Build alternative redis versions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   redis-cluster:
     environment:
      IP: ${REDIS_CLUSTER_IP}
+     SENTINEL: ${REDIS_USE_SENTINEL}
     build:
       context: .
       args:
@@ -10,3 +11,4 @@ services:
     hostname: server
     ports:
       - '7000-7007:7000-7007'
+      - '5000-5002:5000-5002'

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -22,6 +22,14 @@ if [ "$1" = 'redis-cluster' ]; then
       else
         PORT=${port} envsubst < /redis-conf/redis.tmpl > /redis-conf/${port}/redis.conf
       fi
+
+      if [ "$port" -lt "7003" ]; then
+        if [ "$SENTINEL" = "true" ]; then
+          PORT=${port} SENTINEL_PORT=$((port - 2000)) envsubst < /redis-conf/sentinel.tmpl > /redis-conf/sentinel-${port}.conf
+          cat /redis-conf/sentinel-${port}.conf
+        fi
+      fi
+
     done
 
     bash /generate-supervisor-conf.sh $max_port > /etc/supervisor/supervisord.conf
@@ -34,6 +42,11 @@ if [ "$1" = 'redis-cluster' ]; then
         IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
     fi
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
+
+    for port in 7000 7001 7002; do
+      redis-sentinel /redis-conf/sentinel-7000.conf &
+    done
+
     tail -f /var/log/supervisor/redis*.log
 else
   exec "$@"

--- a/docker-data/sentinel.tmpl
+++ b/docker-data/sentinel.tmpl
@@ -1,0 +1,5 @@
+port ${SENTINEL_PORT}
+sentinel monitor sentinel${PORT} 127.0.0.1 ${PORT} 2
+sentinel down-after-milliseconds sentinel${PORT} 5000
+sentinel failover-timeout sentinel${PORT} 60000
+sentinel parallel-syncs sentinel${PORT} 1


### PR DESCRIPTION
This PR adds 3 optional Sentinels on ports `5000`(name: `sentinel7000`), `5001` (`sentinel7001`), and `5002` (`sentinel7001`), that map to master nodes running on `7000`, `7001`, and `7002`, respectively.
They are not running by default, but have to be turned on using `-e "SENTINEL=true"` flag.
I have temporarily pushed the image to Docker Hub under `pcej/redis-cluster:latest` if anyone wants to test.
I have been running the Docker container with:
```
docker run \
  -e "SENTINEL=true" \
  -e "IP=0.0.0.0" \
  -p 7000:7000 \
  -p 5000:5000 \
  --name redis-cluster \
  pcej/redis-cluster:latest
```
and then testing with:
```
redis-cli -p 5000
127.0.0.1:5000> sentinel master sentinel7000
```