### PR TITLE
Fix getting $IP value

### DIFF
--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -29,10 +29,11 @@ if [ "$1" = 'redis-cluster' ]; then
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 3
 
-    # If IP is unset then discover it
-    if [ -z "$IP" ]; then
-        IP=$(ifconfig | grep -P "\s+inet 17" | awk -F ' ' '{print $2}')
+    if [ -z "$IP" ]; then # If IP is unset then discover it
+        IP=$(hostname -I)
     fi
+    IP=$(echo ${IP}) # trim whitespaces
+
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log
 else

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'redis-cluster' ]; then
 
     # If IP is unset then discover it
     if [ -z "$IP" ]; then
-        IP=`ifconfig | grep "inet addr:17" | cut -f2 -d ":" | cut -f1 -d " "`
+        IP=$(ifconfig | grep -P "\s+inet 17" | awk -F ' ' '{print $2}')
     fi
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log


### PR DESCRIPTION
Hi, I not detailed investigate it issue, but in my setup (just redis-cluster 3.2.12 & 4.0.10) it fails on entrypoint on string `echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005` because ${IP} was not set, so I change regexp which put value into it variable.