### PR TITLE
Flip standalone instances from opt-out to opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,35 +63,38 @@ To connect to your cluster you can use the redis-cli tool:
     make cli
 
 
-## Omit standalone redis instances
+## Include standalone redis instances
 
-Set env variable CLUSTER_ONLY=true.
+Standalone instances is not enabled by default, but available to use to run 2 standalone redis instances that is not clustered.
 
-* Running with docker compose, modify docker-compose file
+If running with plain docker run
+
+    docker run ... -e STANDALONE=true ...
+
+When running with docker-compose, set the envrionment variable on your system `REDIS_USE_STANDALONE=true` and start your container or modify the `docker-compose.yml` file
 
       version: '2'
       services:
         redis-cluster:
-          build:
-            context: .
-            args:
-              redis_version: '4.0.11'
-          hostname: server
+          ...
         environment:
-          CLUSTER_ONLY: 'true'
-
-* Running with docker directly add:
-
-      docker run ... -e CLUSTER_ONLY=true ...
+          STANDALONE: 'true'
 
 
 ## Include sentinel instances
 
 Sentinel instances is not enabled by default.
 
+If running with plain docker send in `-e SENTINEL=true`.
+
 When running with docker-compose set the environment variable on your system `REDIS_USE_SENTINEL=true` and start your container.
 
-If running with plain docker send in `-e SENTINEL=true`.
+      version: '2'
+      services:
+        redis-cluster:
+          ...
+        environment:
+          SENTINEL: 'true'
 
 
 ## Build alternative redis versions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
      IP: ${REDIS_CLUSTER_IP}
      SENTINEL: ${REDIS_USE_SENTINEL}
+     STANDALONE: ${REDIS_USE_STANDALONE}
     build:
       context: .
       args:

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -4,9 +4,9 @@ if [ "$1" = 'redis-cluster' ]; then
     # Allow passing in cluster IP by argument or environmental variable
     IP="${2:-$IP}"
 
-    max_port=7007
-    if [ "$CLUSTER_ONLY" = "true" ]; then
-      max_port=7005
+    max_port=7005
+    if [ "$STANDALONE" = "true" ]; then
+      max_port=7007
     fi
 
     for port in `seq 7000 $max_port`; do


### PR DESCRIPTION
To follow the same setup as SENTINEL, this streamlines the functionality to be the same and that by default, only a redis cluster is started, but standalone and sentinel instances is optional to include.