### PR TITLE
Only start up sentinel if ENV is set

### DIFF
--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -53,10 +53,11 @@ if [ "$1" = 'redis-cluster' ]; then
       echo "yes" | /redis/src/redis-cli --cluster create --cluster-replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     fi
 
-
-    for port in 7000 7001 7002; do
-      redis-sentinel /redis-conf/sentinel-7000.conf &
-    done
+    if [ "$SENTINEL" = "true" ]; then
+      for port in 7000 7001 7002; do
+        redis-sentinel /redis-conf/sentinel-${port}.conf &
+      done
+    fi
 
     tail -f /var/log/supervisor/redis*.log
 else


### PR DESCRIPTION
Prevent these errors:
```
redis-cluster_1  | 69:X 27 Nov 19:33:52.168 # Fatal error, can't open config file '/redis-conf/sentinel-7002.conf'
redis-cluster_1  | 68:X 27 Nov 19:33:52.169 # Fatal error, can't open config file '/redis-conf/sentinel-7001.conf'
```