### PR TITLE
Remove pre-existing data to avoid failing to restart cluster

### DIFF
--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -17,6 +17,14 @@ if [ "$1" = 'redis-cluster' ]; then
         rm /redis-data/${port}/nodes.conf
       fi
 
+      if [ -e /redis-data/${port}/dump.rdb ]; then
+        rm /redis-data/${port}/dump.rdb
+      fi
+
+      if [ -e /redis-data/${port}/appendonly.aof ]; then
+        rm /redis-data/${port}/appendonly.aof
+      fi
+
       if [ "$port" -lt "7006" ]; then
         PORT=${port} envsubst < /redis-conf/redis-cluster.tmpl > /redis-conf/${port}/redis.conf
       else


### PR DESCRIPTION
Fix the following errors occurring when there's pre-existing data and restart docker-redis-cluster:
`[ERR] Node 172.22.0.2:7001 is not empty. Either the node already knows other nodes (check with CLUSTER NODES) or contains some key in database 0.`
 
This might be related to #55 