### PR TITLE
:sparkles: Stop on SIGTERM (Ctrl-C in terminal)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -67,7 +67,7 @@ if [ "$1" = 'redis-cluster' ]; then
       done
     fi
 
-    tail -f /var/log/supervisor/redis*.log
+    tail -f /var/log/supervisor/redis*.log & wait $!
 else
   exec "$@"
 fi


### PR DESCRIPTION
Hi 👋 

First of all, thanks for your work 👏 
We're using it everyday on our project 😄 

We can't stop the container by simply using Ctrl-C in terminal.
Actually, we do need to use docker cli to stop it.

This PR makes use of `wait` in order to handle SIGTERM signal in the container when Ctrl-C is pressed in the terminal.