### PR TITLE
Correct order of -e in docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ export REDIS_CLUSTER_IP=0.0.0.0
 If you are downloading the container from dockerhub, you must add the internal IP envrionment variable to your `docker run` command.
 
 ```
-docker run grokzen/redis-cluster:latest -e "IP=0.0.0.0" ...
+docker run  -e "IP=0.0.0.0" grokzen/redis-cluster:latest ...
 ```
 
 


### PR DESCRIPTION
the -e and mapping must be before the image name