### PR TITLE
Fix - generate-supervisor-conf.sh hangs when you put big port in INITIAL_PORT

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -64,7 +64,7 @@ if [ "$1" = 'redis-cluster' ]; then
 
     done
 
-    bash /generate-supervisor-conf.sh $max_port > /etc/supervisor/supervisord.conf
+    bash /generate-supervisor-conf.sh $INITIAL_PORT $max_port > /etc/supervisor/supervisord.conf
 
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 3

--- a/generate-supervisor-conf.sh
+++ b/generate-supervisor-conf.sh
@@ -1,4 +1,5 @@
-max_port="$1"
+min_port="$1"
+max_port="$2"
 
 program_entry_template ()
 {
@@ -20,7 +21,7 @@ nodaemon=false
 "
 
 count=1
-for port in `seq 7000 $max_port`; do
+for port in `seq $min_port $max_port`; do
   result_str="$result_str$(program_entry_template $count $port)"
   count=$((count + 1))
 done


### PR DESCRIPTION
generate-supervisor-conf.sh - should get min port as parameter 

