### PR TITLE
Added support for password

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [ "$1" = 'redis-cluster' ]; then
       fi
 
       if [ "$port" -lt "$first_standalone" ]; then
-        PORT=${port} envsubst < /redis-conf/redis-cluster.tmpl > /redis-conf/${port}/redis.conf
+        PORT=${port} REQUIREPASS=${REQUIREPASS:-} envsubst < /redis-conf/redis-cluster.tmpl > /redis-conf/${port}/redis.conf
         nodes="$nodes $IP:$port"
       else
         PORT=${port} envsubst < /redis-conf/redis.tmpl > /redis-conf/${port}/redis.conf
@@ -84,7 +84,13 @@ if [ "$1" = 'redis-cluster' ]; then
       echo "yes" | eval ruby /redis/src/redis-trib.rb create --replicas "$SLAVES_PER_MASTER" "$nodes"
     else
       echo "Using redis-cli to create the cluster"
-      echo "yes" | eval /redis/src/redis-cli --cluster create --cluster-replicas "$SLAVES_PER_MASTER" "$nodes"
+      if [ -z "$REQUIREPASS" ];
+      then
+        PASSWD_ARG=""
+      else
+        PASSWD_ARG="-a $REQUIREPASS"
+      fi
+      echo "yes" | eval /redis/src/redis-cli --cluster create --cluster-replicas "$SLAVES_PER_MASTER" "$PASSWD_ARG" "$nodes"
     fi
 
     if [ "$SENTINEL" = "true" ]; then

--- a/redis-cluster.tmpl
+++ b/redis-cluster.tmpl
@@ -5,3 +5,5 @@ cluster-config-file nodes.conf
 cluster-node-timeout 5000
 appendonly yes
 dir /redis-data/${PORT}
+requirepass "${REQUIREPASS}"
+masterauth "${REQUIREPASS}"


### PR DESCRIPTION
A password can be specified by passing a `REQUIREPASS` environment variable.
This password is set for both the `requirepass` and `masterauth` configuration parameters for all servers in the cluster.