### PR TITLE
Add IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ Also note that the number of sentinels (if enabled) is the same as the number of
           SLAVES_PER_MASTER: 2
 
 
+## IPv6 support
+
+By default, redis instances will bind and accept requests from any IPv4 network.
+This is configurable by an environment variable that specifies which address a redis instance will bind to.
+By using the IPv6 variant `::` as counterpart to IPv4s `0.0.0.0` an IPv6 cluster can be created.
+
+| Environment variable | Default |
+| -------------------- | ------: |
+| `BIND_ADDRESS`       | 0.0.0.0 |
+
+Note that Docker also needs to be [configured](https://docs.docker.com/config/daemon/ipv6/) for IPv6 support.
+Unfortunately Docker does not handle IPv6 NAT so, when acceptable, `--network host` can be used.
+
+    # Example using plain docker
+    docker run -e "IP=::1" -e "BIND_ADDRESS=::" --network host grokzen/redis-cluster:latest
+
+
 ## Build alternative redis versions
 
 For a release to be buildable it needs to be present at this url: http://download.redis.io/releases/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,6 +26,10 @@ if [ "$1" = 'redis-cluster' ]; then
       SLAVES_PER_MASTER=1
     fi
 
+    if [ -z "$BIND_ADDRESS" ]; then # Default to any IPv4 address
+      BIND_ADDRESS=0.0.0.0
+    fi
+
     max_port=$(($INITIAL_PORT + $MASTERS * ( $SLAVES_PER_MASTER  + 1 ) - 1))
     first_standalone=$(($max_port + 1))
     if [ "$STANDALONE" = "true" ]; then
@@ -52,10 +56,10 @@ if [ "$1" = 'redis-cluster' ]; then
       fi
 
       if [ "$port" -lt "$first_standalone" ]; then
-        PORT=${port} envsubst < /redis-conf/redis-cluster.tmpl > /redis-conf/${port}/redis.conf
+        PORT=${port} BIND_ADDRESS=${BIND_ADDRESS} envsubst < /redis-conf/redis-cluster.tmpl > /redis-conf/${port}/redis.conf
         nodes="$nodes $IP:$port"
       else
-        PORT=${port} envsubst < /redis-conf/redis.tmpl > /redis-conf/${port}/redis.conf
+        PORT=${port} BIND_ADDRESS=${BIND_ADDRESS} envsubst < /redis-conf/redis.tmpl > /redis-conf/${port}/redis.conf
       fi
 
       if [ "$port" -lt $(($INITIAL_PORT + $MASTERS)) ]; then

--- a/redis-cluster.tmpl
+++ b/redis-cluster.tmpl
@@ -1,4 +1,4 @@
-bind 0.0.0.0
+bind ${BIND_ADDRESS}
 port ${PORT}
 cluster-enabled yes
 cluster-config-file nodes.conf

--- a/redis.tmpl
+++ b/redis.tmpl
@@ -1,4 +1,4 @@
-bind 0.0.0.0
+bind ${BIND_ADDRESS}
 port ${PORT}
 appendonly yes
 dir /redis-data/${PORT}


### PR DESCRIPTION
Added a config `BIND_ADDRESS` that specifies which address redis instances
binds to. This enables creation of IPv6 clusters and stand-alone instances.