### PR TITLE
Add arm support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Build based on redis:6.0 from 2020-05-05
-FROM redis@sha256:f7ee67d8d9050357a6ea362e2a7e8b65a6823d9b612bc430d057416788ef6df9
+FROM redis:6.0.16
 
 LABEL maintainer="Johan Andersson <Grokzen@gmail.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "  cli           run redis-cli inside the container on the server with port 7000"
 
 build:
-	docker buildx build --build-arg redis_version=6.2.1 --platform linux/amd64,linux/arm64 --tag grokzen/redis-cluster:latest .
+	docker buildx build --build-arg redis_version=6.2.1 --platform linux/amd64,linux/arm64 --tag grokzen/redis-cluster:local .
 
 up:
 	@echo "Ensure that you have run `make build` to use the latest image"

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ help:
 	@echo "  cli           run redis-cli inside the container on the server with port 7000"
 
 build:
-	docker-compose build
+	docker buildx build --build-arg redis_version=6.2.1 --platform linux/amd64,linux/arm64,linux/arm/v7 --tag grokzen/redis-cluster:latest .
 
 up:
+	@echo "Ensure that you have run `make build` to use the latest image"
 	docker-compose up
 
 down:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "  cli           run redis-cli inside the container on the server with port 7000"
 
 build:
-	docker buildx build --build-arg redis_version=6.2.1 --platform linux/amd64,linux/arm64,linux/arm/v7 --tag grokzen/redis-cluster:latest .
+	docker buildx build --build-arg redis_version=6.2.1 --platform linux/amd64,linux/arm64 --tag grokzen/redis-cluster:latest .
 
 up:
 	@echo "Ensure that you have run `make build` to use the latest image"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
      SENTINEL: ${REDIS_USE_SENTINEL}
      STANDALONE: ${REDIS_USE_STANDALONE}
     # We are building the image via `make build` which uses buildx since we need it build an multi-arch image.
-    image: grokzen/redis-cluster:latest
+    image: grokzen/redis-cluster:local
     hostname: server
     ports:
       - '7000-7050:7000-7050'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,8 @@ services:
      IP: ${REDIS_CLUSTER_IP}
      SENTINEL: ${REDIS_USE_SENTINEL}
      STANDALONE: ${REDIS_USE_STANDALONE}
-    build:
-      context: .
-      args:
-        redis_version: '6.2.1'
+    # We are building the image via `make build` which uses buildx since we need it build an multi-arch image.
+    image: grokzen/redis-cluster:latest
     hostname: server
     ports:
       - '7000-7050:7000-7050'


### PR DESCRIPTION
This PR adds basic `linux/arm64` support via docker's new `buildx`. For now, we're adding `linux/amd64` and `linux/arm64` only but it is fairly trivial to add more platforms.

This does change the development experience: Since docker-compose can't natively build an multi-arch image, we are moving that phase into the `make build` command. In order to spin up a local dev environment, you now need to run `make build` before running `make up`. Unfortunately I'm not aware of a better way to solve this.

Closes #133 